### PR TITLE
深いインデントと画像の組み合わせのバグ修正

### DIFF
--- a/client/scrapboxlib/blockify.js
+++ b/client/scrapboxlib/blockify.js
@@ -105,8 +105,10 @@ const addBlockInfo = lines => {
       prevLine._gyazoImageId = getGyazoImageId(prevLine._srcUrl)
       prevLine._type = 'image'
 
-      // キャプションは無かプレーンテキストであるべき
-      const deeper = currentIndent === 0 || currentIndent > prevLine.indent
+      // 画像行のindent=0の場合に限り、indent=0のキャプション行があり得る
+      // その他のケースでは、画像行のindentよりもキャプション行の方が深い
+      // また、キャプションは無かプレーンテキストであるべき
+      const deeper = (prevLine.indent === 0 && currentIndent === 0) || currentIndent > prevLine.indent
       if (deeper && (currentLine.nodes.length === 0 || currentLine.nodes[0].type === 'plain')) {
         prevLine._captionNodes = currentLine.nodes
         continue

--- a/client/scrapboxlib/test/figure.js
+++ b/client/scrapboxlib/test/figure.js
@@ -269,6 +269,37 @@ const cases = [
     ]
   },
   {
+    name: 'return to plain line with indent level 0 from image located in deep indent with no caption',
+    source: [
+      'Test',
+      '\tlevel-1',
+      '\t\tlevel-2',
+      '\t\t\t[https://gyazo.com/3d30566b55e2f511f07b7826a7af77f6]',
+      'level-0 plain line'
+    ],
+    expect: [
+      'Test',
+      '\\begin{itemize}', // 1
+      '  \\item level-1',
+      '  \\begin{itemize}', // 2
+      '    \\item level-2',
+      '    \\begin{itemize}', // 3
+      '      \\item \\begin{minipage}[t]{\\linewidth}',
+      '        \\vspace{0.5truemm}',
+      '        \\begin{center}',
+      '          \\includegraphics[width=0.5\\linewidth]{./cmyk-gray-gyazo-images/3d30566b55e2f511f07b7826a7af77f6.jpg}',
+      '          % no caption',
+      '          \\vspace{3truemm}',
+      '          \\label{fig:gyazo-id-3d30566b55e2f511f07b7826a7af77f6}',
+      '        \\end{center}',
+      '      \\end{minipage}',
+      '    \\end{itemize}', // 3
+      '  \\end{itemize}', // 2
+      '\\end{itemize}', // 1
+      'level-0 plain line\\\\'
+    ]
+  },
+  {
     name: 'image without a caption deep inside the itemize',
     source: [
       'Test successful return from deep indentation',


### PR DESCRIPTION
https://scrapbox.io/daiiz-pimento-dev/復帰後のlevel_0行の内容がindent_level_3_画像のキャプションになっている
https://scrapbox.io/daiiz-pimento-dev/indent_level_3_のキャプションなし画像で終わると、level_1,_2のitemizeが閉じない
https://scrapbox.io/daiiz-pimento-dev/indent_level_3_のキャプションなし画像で終わると、level_1,_2のitemizeが閉じない＋α