### PR TITLE
TeX Live 2019 対応: gentombow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tmp/*
 
 参考.txt
 old_code/*
+old/*
 
 ### https://raw.github.com/github/gitignore/55df35ee63aef4a6f859559af980c9fb87bee1a1/Global/macOS.gitignore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,29 +20,28 @@ RUN apt-get install -y \
   texlive-generic-extra
 
 # tlmgr
-RUN tlmgr init-usertree
-RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/
-RUN tlmgr install gentombow
-# RUN tlmgr install bxpapersize
-RUN tlmgr install pdfx
-RUN tlmgr install xmpincl
-RUN tlmgr install etoolbox
-RUN tlmgr install xcolor
-RUN tlmgr install titlesec
-RUN tlmgr install bxpapersize
-
-RUN tlmgr install tcolorbox
-RUN tlmgr install pgf
-RUN tlmgr install environ
-RUN tlmgr install trimspaces
-RUN tlmgr install colorprofiles
-
 RUN tlmgr version
+RUN tlmgr init-usertree
+# RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2019/tlnet-final/
+# RUN tlmgr install gentombow
+# RUN tlmgr install pdfx
+# RUN tlmgr install xmpincl
+# RUN tlmgr install etoolbox
+# RUN tlmgr install xcolor
+# RUN tlmgr install titlesec
+# RUN tlmgr install bxpapersize
+
+# RUN tlmgr install tcolorbox
+# RUN tlmgr install pgf
+# RUN tlmgr install environ
+# RUN tlmgr install trimspaces
+# RUN tlmgr install colorprofiles
+
 RUN tlmgr list --only-installed
 
 # gentombow v0.9kやカスタムstyを追加する
-# RUN rm /usr/share/texlive/texmf-dist/tex/latex/gentombow/gentombow.sty
-# COPY sty /usr/share/texlive/texmf-dist/tex/latex/pimento_sty
+RUN rm /usr/share/texlive/texmf-dist/tex/latex/gentombow/gentombow.sty
+COPY sty /usr/share/texlive/texmf-dist/tex/latex/pimento_sty
 RUN texhash
 
 RUN rm /etc/nginx/sites-enabled/default

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
 # tlmgr
 RUN tlmgr version
 RUN tlmgr init-usertree
-# RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2019/tlnet-final/
+# RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/
 # RUN tlmgr install gentombow
 # RUN tlmgr install pdfx
 # RUN tlmgr install xmpincl

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y \
 # tlmgr
 RUN tlmgr init-usertree
 RUN tlmgr option repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/
-# RUN tlmgr install gentombow
+RUN tlmgr install gentombow
 # RUN tlmgr install bxpapersize
 RUN tlmgr install pdfx
 RUN tlmgr install xmpincl
@@ -42,7 +42,7 @@ RUN tlmgr list --only-installed
 
 # gentombow v0.9kやカスタムstyを追加する
 # RUN rm /usr/share/texlive/texmf-dist/tex/latex/gentombow/gentombow.sty
-COPY sty /usr/share/texlive/texmf-dist/tex/latex/pimento_sty
+# COPY sty /usr/share/texlive/texmf-dist/tex/latex/pimento_sty
 RUN texhash
 
 RUN rm /etc/nginx/sites-enabled/default

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ TIMEZONE := Asia/Tokyo
 build:
 	docker build -t daiiz/pimento:$(VERSION) .
 
+build-no-cache:
+	docker build --no-cache -t daiiz/pimento:$(VERSION) .
+
 run-server:
 	docker run --rm -it --name pimento \
 		-e TZ=$(TIMEZONE) \

--- a/apps/pimento.py
+++ b/apps/pimento.py
@@ -81,7 +81,10 @@ def build_page_or_book(page_title_hash, build_options, docDir):
   if refresh and os.path.isfile(auxFilePath):
     os.remove(auxFilePath)
   try:
-    subprocess.check_call(['lualatex', '-interaction', 'batchmode', texFileName], shell=False, cwd=workDir)
+    if is_local_tools_mode():
+      subprocess.check_call(['lualatex', texFileName], shell=False, cwd=workDir)
+    else:
+      subprocess.check_call(['lualatex', '-interaction', 'batchmode', texFileName], shell=False, cwd=workDir)
   except Exception as e:
     pass
 


### PR DESCRIPTION
#57 でDockerのベースイメージを更新したことにより、TeX Live 2019 がインストールされるようになった。
トリミングサイズがおかしくなった。(仕上がりサイズがB5の場合、一回り大きいA4になるはずだが、B5のままになった)

```
This is LuaTeX, Version 1.07.0 (TeX Live 2019/dev/Debian)
```

![](https://gyazo.com/098b022f65af9551616c861574a746ff/thumb/400)

---

- Tex Live 2019 によってインストールされた gentombow を削除する
  - $ rm /usr/share/texlive/texmf-dist/tex/latex/gentombow/gentombow.sty
- 自前で用意したバージョン 0.9k (pdfxとの共存に対応したバージョン) の gentombow をコピーする
  -  詳細: https://ctan.math.washington.edu/tex-archive/macros/latex/contrib/gentombow/gentombow.pdf

```tex
\documentclass[b5paper,10.5pt,titlepage,openany]{ltjsbook}
\usepackage{graphicx}
\usepackage[x-1a3]{pdfx}
\usepackage[pdfbox]{gentombow}
```

コンパイル時のログ
```log
(/usr/share/texlive/texmf-dist/tex/latex/pimento_sty/gentombow.sty
***** Package gentombow detected b5paper. *****
***** Now the output size is automatically set to a4. *****
)
```

![](https://gyazo.com/de0b1cc7e12e34d22409c15f451d610a/raw)

- 仕上がりサイズ: B5
- トリミングサイズ: A4
